### PR TITLE
Fix the grid_map build with the new build system changes.

### DIFF
--- a/grid_map_demos/CMakeLists.txt
+++ b/grid_map_demos/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 find_package(octomap REQUIRED)
+message(STATUS "Found Octomap (version ${octomap_VERSION}): ${OCTOMAP_INCLUDE_DIRS}")
 
 ###################################
 ## catkin specific configuration ##
@@ -36,7 +37,7 @@ find_package(octomap REQUIRED)
 catkin_package(
   INCLUDE_DIRS include
 #  LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS
+  CATKIN_DEPENDS octomap
 #  DEPENDS system_lib
 )
 
@@ -50,7 +51,7 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${EIGEN3_INCLUDE_DIR}
-  ${OCTOMAP_INCLUDE_DIR}
+  ${OCTOMAP_INCLUDE_DIRS}
 )
 
 ## Declare a cpp executable
@@ -132,7 +133,8 @@ target_link_libraries(
 target_link_libraries(
   octomap_to_gridmap_demo
   ${catkin_LIBRARIES}
-  ${OCTOMAP_LIBRARIES}
+  ${OCTOMAP_LIBRARY}
+  ${OCTOMATH_LIBRARY}
 )
 
 target_link_libraries(

--- a/grid_map_demos/package.xml
+++ b/grid_map_demos/package.xml
@@ -23,4 +23,5 @@
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>octomap_msgs</depend>
+  <depend>octomap</depend>
 </package>


### PR DESCRIPTION
Make grid_map depend on the octomap build, and link in the octomap libraries correctly.

This corresponds with the mBot build system changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/marbleinc/grid_map/3)
<!-- Reviewable:end -->
